### PR TITLE
Upgrade thiserror to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["code128", "barcode"]
 
 [features]
 default = ["std", "unicode"]
-std = ["dep:thiserror"]
+std = ["thiserror/std"]
 unicode = []
 
 [dependencies]
-thiserror = { version = "1.0.40", optional = true }
+thiserror = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 atty = "0.2.14"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2,44 +2,39 @@ use crate::std::string::String;
 use crate::std::vec;
 use crate::std::vec::Vec;
 
-#[cfg(feature = "std")]
 use thiserror::Error;
 
 use crate::Bar;
 
 /// Errors that can occur during decoding.
-#[derive(Debug, PartialEq)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Debug, PartialEq, Error)]
 pub enum DecodingError {
     /// A sequence of modules resulted in an unknown pattern.
-    #[cfg_attr(feature = "std", error("pattern {0:b} not recognized"))]
+    #[error("pattern {0:b} not recognized")]
     Pattern(u16),
     /// A bar's width or spacing is not valid.
-    #[cfg_attr(feature = "std", error("bar is not valid"))]
+    #[error("bar is not valid")]
     InvalidBar,
     /// The stop code at the end is wrong.
-    #[cfg_attr(feature = "std", error("wrong stop code"))]
+    #[error("wrong stop code")]
     WrongStop,
     /// The input was too short.
-    #[cfg_attr(feature = "std", error("code too short to be valid"))]
+    #[error("code too short to be valid")]
     Short,
     /// The code's length can not fit an allowed sequence of modules.
-    #[cfg_attr(feature = "std", error("length not correct"))]
+    #[error("length not correct")]
     Length,
     /// The checksum did not match.
-    #[cfg_attr(feature = "std", error("checksum mismatch"))]
+    #[error("checksum mismatch")]
     Checksum,
     /// The code did not start with a mode signal.
-    #[cfg_attr(feature = "std", error("start char did not signal mode"))]
+    #[error("start char did not signal mode")]
     NoMode,
     /// A symbol occurred in a mode that did not support it or is not implemented.
-    #[cfg_attr(feature = "std", error("unexpected character {0:x}"))]
+    #[error("unexpected character {0:x}")]
     Unexpected(u8),
     /// After decoding the data the conversion from Latin 1 failed.
-    #[cfg_attr(
-        feature = "std",
-        error("characters not covered by Latin 1 were part of this symbol")
-    )]
+    #[error("characters not covered by Latin 1 were part of this symbol")]
     Latin1,
 }
 


### PR DESCRIPTION
This upgrades `thiserror` to v2, which supports the fact that `std::error::Error` is now also available as `core::error::Error` since Rust v1.81.